### PR TITLE
feat(actions): populate FCTM_documents en getActionById

### DIFF
--- a/services/action.service.js
+++ b/services/action.service.js
@@ -7,7 +7,7 @@ const { insertManyDocuments } = require("./document.service")
 exports.getAll = () => actionModel.find()
 
 //Obtener accion por id
-exports.getById = async(id) => actionModel.findById(id)
+exports.getById = async(id) => actionModel.findById(id).populate('FCTM_documents')
 
 //Crear una nueva accion
 exports.create = async({

--- a/services/action.service.js
+++ b/services/action.service.js
@@ -30,8 +30,6 @@ exports.create = async({
         visible_to_profiles: ["ADMINISTRADOR", "PROFESOR"]
     }
 
-    console.log(files)
-
     if(files && files.length > 0){
         filesID = await insertManyDocuments(files, datosDocumentos)
     }


### PR DESCRIPTION
Como pedía el issue, he añadido el populate de FCTM_documents en getActionById para que lleguen los datos completos al frontend (sin esto solo llegaban los IDs).

De paso he quitado un console.log que quedó de pruebas.

Closes #185